### PR TITLE
Add OpenWRT, Thali, JXcore

### DIFF
--- a/links/ch_1_connecting_worlds.json
+++ b/links/ch_1_connecting_worlds.json
@@ -28,6 +28,10 @@
         {
           "name": "Intel Edison project showcases (Japan)",
           "link": "http://edison-lab.jp/"
+        },
+        {
+          "name": "Thali - Framework for connected devices",
+          "link": "http://thaliproject.org/"
         }
       ]
     },
@@ -37,6 +41,15 @@
         {
           "link": "https://nodejs.org/api/fs.html",
           "name": "File System API Docs"
+        }
+      ]
+    },
+    {
+      "name": "JXcore",
+      "links": [
+        {
+          "link": "https://github.com/jxcore/jxcore/blob/master/doc/native/Embedding_Basics.md",
+          "name": "Basics of embedding JXcore"
         }
       ]
     }

--- a/links/ch_3_nodejs_on_embedded_linux.json
+++ b/links/ch_3_nodejs_on_embedded_linux.json
@@ -27,6 +27,15 @@
       ]
     },
     {
+      "name": "OpenWRT",
+      "links": [
+        {
+          "name": "Bundle JXcore for OpenWRT (ARM, mipsel) Memory: 16Mb+",
+          "link": "https://github.com/jxcore/jxcore/blob/master/doc/OpenWrt_Compile.md"
+        }
+      ]
+    },
+    {
       "name": "Beaglebone",
       "links": [
         {


### PR DESCRIPTION
Adding list of related links given below:
- Thali - Framework for connected devices
- Basics of embedding JXcore
- Bundle JXcore for OpenWRT (ARM, mipsel) Memory: 16Mb+
