### PR TITLE
Add link to lightweight mqtt machine network - inspired by MQTT.js and Mosca

### DIFF
--- a/links/ch_11_entering_the_cloud.json
+++ b/links/ch_11_entering_the_cloud.json
@@ -40,6 +40,10 @@
         {
           "name": "HiveMQ Broker",
           "link": "http://www.hivemq.com/try-out/"
+        },
+        {
+          "name": "Lightweight MQTT Machine Network",
+          "link": "http://lwmqn.github.io/"
         }
       ]
     },


### PR DESCRIPTION
Hello,

  I add the link of [lightweight mqtt machine network](http://lwmqn.github.io/) (LWMQN) project in **MQTT** section. LWMQN is built on top of MQTT.js, Mosca, LWM2M-like interfaces, and IPSO model to provide a setup for full-stack IoT development with MQTT and node.js.

  I'm not sure if it is appropriate to put it in **Ch 11 - Entering the Cloud**, since  LWMQN is finding its way to take care of **Local Area Machine Networks** with scale from tens to hundred of devices, especially for applications that don't need to touch the outside world (or have no internet). If developers like to let their machines up to cloud, why not? It's node.js!
